### PR TITLE
Add async versions of before and after hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,50 +6,193 @@
 
 ## Module Test.Mocha
 
-### Types
+#### `Before`
 
-    data After :: !
-
-    data Before :: !
-
-    data Describe :: !
-
-    type DoDescribe  = forall e a. String -> Eff e a -> Eff (describe :: Describe | e) Unit
-
-    type DoIt  = forall e a. String -> Eff e a -> Eff (it :: It | e) Unit
-
-    data Done :: !
-
-    data DoneToken where
-      DoneToken :: DoneToken
-
-    data It :: !
+``` purescript
+data Before :: !
+```
 
 
-### Values
+#### `Describe`
 
-    after :: forall e a. Eff e a -> Eff (after :: After | e) Unit
+``` purescript
+data Describe :: !
+```
 
-    afterEach :: forall e a. Eff e a -> Eff (after :: After | e) Unit
 
-    before :: forall e a. Eff e a -> Eff (before :: Before | e) Unit
+#### `It`
 
-    beforeEach :: forall e a. Eff e a -> Eff (before :: Before | e) Unit
+``` purescript
+data It :: !
+```
 
-    describe :: DoDescribe
 
-    describeOnly :: DoDescribe
+#### `After`
 
-    describeSkip :: DoDescribe
+``` purescript
+data After :: !
+```
 
-    it :: DoIt
 
-    itAsync :: forall a eff. String -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+#### `Done`
 
-    itIs :: forall eff. DoneToken -> Eff (done :: Done | eff) Unit
+``` purescript
+data Done :: !
+```
 
-    itIsNot :: forall eff. DoneToken -> Eff (done :: Done | eff) Unit
 
-    itOnly :: DoIt
+#### `DoIt`
 
-    itSkip :: DoIt
+``` purescript
+type DoIt = forall e a. String -> Eff e a -> Eff (it :: It | e) Unit
+```
+
+
+#### `DoDescribe`
+
+``` purescript
+type DoDescribe = forall e a. String -> Eff (describe :: Describe | e) a -> Eff (describe :: Describe | e) Unit
+```
+
+
+#### `DoBefore`
+
+``` purescript
+type DoBefore = forall e a. Eff e a -> Eff (before :: Before | e) Unit
+```
+
+
+#### `DoAfter`
+
+``` purescript
+type DoAfter = forall e a. Eff e a -> Eff (after :: After | e) Unit
+```
+
+
+#### `DoneToken`
+
+``` purescript
+data DoneToken
+  = DoneToken 
+```
+
+
+#### `describe`
+
+``` purescript
+describe :: DoDescribe
+```
+
+
+#### `describeOnly`
+
+``` purescript
+describeOnly :: DoDescribe
+```
+
+
+#### `describeSkip`
+
+``` purescript
+describeSkip :: DoDescribe
+```
+
+
+#### `it`
+
+``` purescript
+it :: DoIt
+```
+
+
+#### `itOnly`
+
+``` purescript
+itOnly :: DoIt
+```
+
+
+#### `itSkip`
+
+``` purescript
+itSkip :: DoIt
+```
+
+
+#### `itAsync`
+
+``` purescript
+itAsync :: forall a eff. String -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```
+
+
+#### `itIs`
+
+``` purescript
+itIs :: forall eff. DoneToken -> Eff (done :: Done | eff) Unit
+```
+
+
+#### `itIsNot`
+
+``` purescript
+itIsNot :: forall eff a. DoneToken -> Eff (done :: Done | eff) Unit
+```
+
+
+#### `before`
+
+``` purescript
+before :: DoBefore
+```
+
+Before Hooks
+
+#### `beforeEach`
+
+``` purescript
+beforeEach :: DoBefore
+```
+
+
+#### `beforeAsync`
+
+``` purescript
+beforeAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```
+
+
+#### `beforeEachAsync`
+
+``` purescript
+beforeEachAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```
+
+
+#### `after`
+
+``` purescript
+after :: DoAfter
+```
+
+After Hooks
+
+#### `afterEach`
+
+``` purescript
+afterEach :: DoAfter
+```
+
+
+#### `afterAsync`
+
+``` purescript
+afterAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```
+
+
+#### `afterEachAsync`
+
+``` purescript
+afterEachAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```

--- a/src/Test/Mocha.purs
+++ b/src/Test/Mocha.purs
@@ -1,111 +1,172 @@
 module Test.Mocha
-  ( Describe(..), DoDescribe(..)
+  ( Describe(..), DoDescribe(..), DoBefore(..), DoAfter(..)
   , It(..), DoIt(..)
   , itIs, itIsNot, Done(..), DoneToken(..)
   , it, itAsync, itSkip, itOnly
   , describe, describeSkip, describeOnly
-  , before, beforeEach, Before(..)
-  , after, afterEach, After(..)) where
+  , before, beforeEach, beforeAsync, beforeEachAsync, Before(..)
+  , after, afterEach, afterAsync, afterEachAsync, After(..)
+  ) where
 
 import Control.Monad.Eff
 import Data.Foreign.OOFFI
 import Context
 
+foreign import data Before :: !
 foreign import data Describe :: !
+foreign import data It :: !
+foreign import data After :: !
+foreign import data Done :: !
+
+type DoIt = forall e a.
+  String ->
+  Eff e a ->
+  Eff (it :: It | e) Unit
+
 type DoDescribe = forall e a.
-  String -> Eff (describe :: Describe | e) a -> Eff (describe :: Describe | e) Unit
+  String ->
+  Eff (describe :: Describe | e) a ->
+  Eff (describe :: Describe | e) Unit
+
+type DoBefore = forall e a.
+  Eff e a ->
+  Eff (before :: Before | e) Unit
+
+type DoAfter = forall e a.
+  Eff e a ->
+  Eff (after :: After | e) Unit
+
+data DoneToken = DoneToken
 
 describe :: DoDescribe
 describe = method2EffC "describe"
 
 foreign import describeOnly
   """function describeOnly(description) {
-    return function(fn) {
-      return function() {
-        PS.Context.getContext().describe.only(description, fn);
+      return function(fn) {
+        return function() {
+          PS.Context.getContext().describe.only(description, fn);
+        }
       }
-    }
   }""" :: DoDescribe
 
 foreign import describeSkip
   """function describeSkip(description) {
-    return function(fn) {
-      return function() {
-        PS.Context.getContext().describe.skip(description, fn);
+      return function(fn) {
+        return function() {
+          PS.Context.getContext().describe.skip(description, fn);
+        }
       }
-    }
   }""" :: DoDescribe
-
-foreign import data It :: !
-type DoIt = forall e a. String -> Eff e a -> Eff (it :: It | e) Unit
 
 it :: DoIt
 it = method2EffC "it"
 
 foreign import itOnly
   """function itOnly(description) {
-    return function(fn) {
-      return function() {
-        PS.Context.getContext().it.only(description, fn);
+      return function(fn) {
+        return function() {
+          PS.Context.getContext().it.only(description, fn);
+        }
       }
-    }
   }""" :: DoIt
 
 foreign import itSkip
   """function itSkip(description) {
-    return function(fn) {
-      return function() {
-        PS.Context.getContext().it.skip(description, fn);
+      return function(fn) {
+        return function() {
+          PS.Context.getContext().it.skip(description, fn);
+        }
       }
-    }
   }""" :: DoIt
 
-foreign import data Done :: !
-data DoneToken = DoneToken
-
 foreign import itAsync
-  """function itAsync(d) {
+  """function itAsync(description) {
       return function (fn) {
-         return function(){
-           return PS.Context.getContext().it(d, function(done){
-             return fn(done)();
-           });
-         };
+        return function() {
+          return PS.Context.getContext().it(description, function(done) {
+            return fn(done)();
+          });
+        };
       };
   }""" :: forall a eff.
-         String ->
-         (DoneToken -> Eff (done :: Done | eff) a) ->
-         Eff (it :: It | eff) Unit
+          String ->
+          (DoneToken -> Eff (done :: Done | eff) a) ->
+          Eff (it :: It | eff) Unit
 
 foreign import itIs
-  "function itIs(d){ return function(){d();} }" :: forall eff.
-                                       DoneToken ->
-                                       Eff (done :: Done | eff) Unit
+  """function itIs(done) {
+      return function() {
+        done();
+      };
+  }""" :: forall eff.
+          DoneToken ->
+          Eff (done :: Done | eff) Unit
 
 foreign import itIsNot
-  "function itIsNot(d){ return function(){}; }" :: forall eff.
-                                       DoneToken ->
-                                       Eff (done :: Done | eff) Unit
+  """function itIsNot(done) {
+      return function() {
+      };
+  }""" :: forall eff a.
+          DoneToken ->
+          Eff (done :: Done | eff) Unit
 
+-- | Before Hooks
 
-    --- HOOKS
-
-
-foreign import data Before :: !
-
-before :: forall e a. Eff e a -> Eff (before :: Before | e) Unit
+before :: DoBefore
 before = method1EffC "before"
 
-beforeEach :: forall e a. Eff e a -> Eff (before :: Before | e) Unit
+beforeEach :: DoBefore
 beforeEach = method1EffC "beforeEach"
 
+foreign import beforeAsync
+  """function beforeAsync(fn) {
+      return function() {
+        PS.Context.getContext().before(function(done) {
+          return fn(done)();
+        });
+      };
+  }""" :: forall a eff.
+          (DoneToken -> Eff (done :: Done | eff) a) ->
+          Eff (it :: It | eff) Unit
 
+foreign import beforeEachAsync
+  """function beforeEachAsync(fn) {
+      return function() {
+        PS.Context.getContext().beforeEach(function(done) {
+          return fn(done)();
+        });
+      };
+  }""" :: forall a eff.
+          (DoneToken -> Eff (done :: Done | eff) a) ->
+          Eff (it :: It | eff) Unit
 
-foreign import data After :: !
+-- | After Hooks
 
-after :: forall e a. Eff e a -> Eff (after :: After | e) Unit
+after :: DoAfter
 after = method1EffC "after"
 
-afterEach :: forall e a. Eff e a -> Eff (after :: After | e) Unit
+afterEach :: DoAfter
 afterEach = method1EffC "afterEach"
 
+foreign import afterAsync
+  """function afterAsync(fn) {
+      return function() {
+        PS.Context.getContext().after(function(done) {
+          return fn(done)();
+        });
+      };
+  }""" :: forall a eff.
+          (DoneToken -> Eff (done :: Done | eff) a) ->
+          Eff (it :: It | eff) Unit
+
+foreign import afterEachAsync
+  """function afterEachAsync(fn) {
+      return function() {
+        PS.Context.getContext().afterEach(function(done) {
+          return fn(done)();
+        });
+      };
+  }""" :: forall a eff.
+          (DoneToken -> Eff (done :: Done | eff) a) ->
+          Eff (it :: It | eff) Unit


### PR DESCRIPTION
Adds asynchronous versions of `before`, `beforeEach`, `after` and `afterEach`:

* `beforeAsync`
* `beforeEachAsync`
* `afterAsync`
* `afterEachAsync`

It uses the `It` effect and it's `DoneToken` to mark completion.