### PR TITLE
Add fail reason to `ItIsNot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ itIs :: forall eff. DoneToken -> Eff (done :: Done | eff) Unit
 #### `itIsNot`
 
 ``` purescript
-itIsNot :: forall eff a. DoneToken -> Eff (done :: Done | eff) Unit
+itIsNot :: forall eff a. DoneToken -> a -> Eff (done :: Done | eff) Unit
 ```
 
 

--- a/src/Test/Mocha.purs
+++ b/src/Test/Mocha.purs
@@ -105,10 +105,14 @@ foreign import itIs
 
 foreign import itIsNot
   """function itIsNot(done) {
-      return function() {
+      return function(reason) {
+        return function() {
+          done(reason);
+        };
       };
   }""" :: forall eff a.
           DoneToken ->
+          a ->
           Eff (done :: Done | eff) Unit
 
 -- | Before Hooks


### PR DESCRIPTION
This triggers the `done` callback with the given
reason which could be anything, but preferably an
error object.

Without this patch, the current implementation is
a noop, causing the test to timeout which may take
a long time based on the configured timeout.