### PR TITLE
Add support for more mocha functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,88 +41,11 @@ data Done :: !
 ```
 
 
-#### `DoIt`
-
-``` purescript
-type DoIt = forall e a. String -> Eff e a -> Eff (it :: It | e) Unit
-```
-
-
-#### `DoDescribe`
-
-``` purescript
-type DoDescribe = forall e a. String -> Eff (describe :: Describe | e) a -> Eff (describe :: Describe | e) Unit
-```
-
-
-#### `DoBefore`
-
-``` purescript
-type DoBefore = forall e a. Eff e a -> Eff (before :: Before | e) Unit
-```
-
-
-#### `DoAfter`
-
-``` purescript
-type DoAfter = forall e a. Eff e a -> Eff (after :: After | e) Unit
-```
-
-
 #### `DoneToken`
 
 ``` purescript
 data DoneToken
   = DoneToken 
-```
-
-
-#### `describe`
-
-``` purescript
-describe :: DoDescribe
-```
-
-
-#### `describeOnly`
-
-``` purescript
-describeOnly :: DoDescribe
-```
-
-
-#### `describeSkip`
-
-``` purescript
-describeSkip :: DoDescribe
-```
-
-
-#### `it`
-
-``` purescript
-it :: DoIt
-```
-
-
-#### `itOnly`
-
-``` purescript
-itOnly :: DoIt
-```
-
-
-#### `itSkip`
-
-``` purescript
-itSkip :: DoIt
-```
-
-
-#### `itAsync`
-
-``` purescript
-itAsync :: forall a eff. String -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
 ```
 
 
@@ -132,67 +55,8 @@ itAsync :: forall a eff. String -> (DoneToken -> Eff (done :: Done | eff) a) -> 
 itIs :: forall eff. DoneToken -> Eff (done :: Done | eff) Unit
 ```
 
-
 #### `itIsNot`
 
 ``` purescript
 itIsNot :: forall eff a. DoneToken -> Eff (done :: Done | eff) Unit
-```
-
-
-#### `before`
-
-``` purescript
-before :: DoBefore
-```
-
-Before Hooks
-
-#### `beforeEach`
-
-``` purescript
-beforeEach :: DoBefore
-```
-
-
-#### `beforeAsync`
-
-``` purescript
-beforeAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
-```
-
-
-#### `beforeEachAsync`
-
-``` purescript
-beforeEachAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
-```
-
-
-#### `after`
-
-``` purescript
-after :: DoAfter
-```
-
-After Hooks
-
-#### `afterEach`
-
-``` purescript
-afterEach :: DoAfter
-```
-
-
-#### `afterAsync`
-
-``` purescript
-afterAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
-```
-
-
-#### `afterEachAsync`
-
-``` purescript
-afterEachAsync :: forall a eff. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
 ```

--- a/README.md
+++ b/README.md
@@ -164,86 +164,8 @@ itSkipAsync' :: DoItAsyncTimeout
 #### `xit`
 
 ``` purescript
-xit :: DoItSync
+xit :: forall eff. String -> Eff eff Unit
 ```
-
-
-#### `xitOnly`
-
-``` purescript
-xitOnly :: DoItSync
-```
-
-
-#### `xitSkip`
-
-``` purescript
-xitSkip :: DoItSync
-```
-
-
-#### `xit'`
-
-``` purescript
-xit' :: DoItSyncTimeout
-```
-
-
-#### `xitOnly'`
-
-``` purescript
-xitOnly' :: DoItSyncTimeout
-```
-
-
-#### `xitSkip'`
-
-``` purescript
-xitSkip' :: DoItSyncTimeout
-```
-
-
-#### `xitAsync`
-
-``` purescript
-xitAsync :: DoItAsync
-```
-
-
-#### `xitOnlyAsync`
-
-``` purescript
-xitOnlyAsync :: DoItAsync
-```
-
-
-#### `xitSkipAsync`
-
-``` purescript
-xitSkipAsync :: DoItAsync
-```
-
-
-#### `xitAsync'`
-
-``` purescript
-xitAsync' :: DoItAsyncTimeout
-```
-
-
-#### `xitOnlyAsync'`
-
-``` purescript
-xitOnlyAsync' :: DoItAsyncTimeout
-```
-
-
-#### `xitSkipAsync'`
-
-``` purescript
-xitSkipAsync' :: DoItAsyncTimeout
-```
-
 
 #### `DoDescribe`
 
@@ -279,17 +201,10 @@ describeSkip :: DoDescribe
 xdescribe :: DoDescribe
 ```
 
-#### `xdescribeOnly`
+#### `xdescribe'`
 
 ``` purescript
-xdescribeOnly :: DoDescribe
-```
-
-
-#### `xdescribeSkip`
-
-``` purescript
-xdescribeSkip :: DoDescribe
+xdescribe' :: forall eff. String -> Eff eff Unit
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,418 @@ data DoneToken
 ```
 
 
+#### `DoItSync`
+
+``` purescript
+type DoItSync = forall a eff. String -> Eff eff a -> Eff (it :: It | eff) Unit
+```
+
+
+#### `it`
+
+``` purescript
+it :: DoItSync
+```
+
+
+#### `itOnly`
+
+``` purescript
+itOnly :: DoItSync
+```
+
+
+#### `itSkip`
+
+``` purescript
+itSkip :: DoItSync
+```
+
+
+#### `DoItSyncTimeout`
+
+``` purescript
+type DoItSyncTimeout = forall a eff. String -> Number -> Eff eff a -> Eff (it :: It | eff) Unit
+```
+
+
+#### `it'`
+
+``` purescript
+it' :: DoItSyncTimeout
+```
+
+
+#### `itOnly'`
+
+``` purescript
+itOnly' :: DoItSyncTimeout
+```
+
+
+#### `itSkip'`
+
+``` purescript
+itSkip' :: DoItSyncTimeout
+```
+
+
+#### `DoItAsync`
+
+``` purescript
+type DoItAsync = forall a eff. String -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```
+
+
+#### `itAsync`
+
+``` purescript
+itAsync :: DoItAsync
+```
+
+
+#### `itOnlyAsync`
+
+``` purescript
+itOnlyAsync :: DoItAsync
+```
+
+
+#### `itSkipAsync`
+
+``` purescript
+itSkipAsync :: DoItAsync
+```
+
+
+#### `DoItAsyncTimeout`
+
+``` purescript
+type DoItAsyncTimeout = forall a eff. String -> Number -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (it :: It | eff) Unit
+```
+
+
+#### `itAsync'`
+
+``` purescript
+itAsync' :: DoItAsyncTimeout
+```
+
+
+#### `itOnlyAsync'`
+
+``` purescript
+itOnlyAsync' :: DoItAsyncTimeout
+```
+
+
+#### `itSkipAsync'`
+
+``` purescript
+itSkipAsync' :: DoItAsyncTimeout
+```
+
+
+#### `xit`
+
+``` purescript
+xit :: DoItSync
+```
+
+
+#### `xitOnly`
+
+``` purescript
+xitOnly :: DoItSync
+```
+
+
+#### `xitSkip`
+
+``` purescript
+xitSkip :: DoItSync
+```
+
+
+#### `xit'`
+
+``` purescript
+xit' :: DoItSyncTimeout
+```
+
+
+#### `xitOnly'`
+
+``` purescript
+xitOnly' :: DoItSyncTimeout
+```
+
+
+#### `xitSkip'`
+
+``` purescript
+xitSkip' :: DoItSyncTimeout
+```
+
+
+#### `xitAsync`
+
+``` purescript
+xitAsync :: DoItAsync
+```
+
+
+#### `xitOnlyAsync`
+
+``` purescript
+xitOnlyAsync :: DoItAsync
+```
+
+
+#### `xitSkipAsync`
+
+``` purescript
+xitSkipAsync :: DoItAsync
+```
+
+
+#### `xitAsync'`
+
+``` purescript
+xitAsync' :: DoItAsyncTimeout
+```
+
+
+#### `xitOnlyAsync'`
+
+``` purescript
+xitOnlyAsync' :: DoItAsyncTimeout
+```
+
+
+#### `xitSkipAsync'`
+
+``` purescript
+xitSkipAsync' :: DoItAsyncTimeout
+```
+
+
+#### `DoDescribe`
+
+``` purescript
+type DoDescribe = forall eff a. String -> Eff (describe :: Describe | eff) a -> Eff (describe :: Describe | eff) Unit
+```
+
+
+#### `describe`
+
+``` purescript
+describe :: DoDescribe
+```
+
+
+#### `describeOnly`
+
+``` purescript
+describeOnly :: DoDescribe
+```
+
+
+#### `describeSkip`
+
+``` purescript
+describeSkip :: DoDescribe
+```
+
+
+#### `xdescribe`
+
+``` purescript
+xdescribe :: DoDescribe
+```
+
+#### `xdescribeOnly`
+
+``` purescript
+xdescribeOnly :: DoDescribe
+```
+
+
+#### `xdescribeSkip`
+
+``` purescript
+xdescribeSkip :: DoDescribe
+```
+
+
+#### `DoBefore`
+
+``` purescript
+type DoBefore = forall eff a. Eff eff a -> Eff (before :: Before | eff) Unit
+```
+
+
+#### `before`
+
+``` purescript
+before :: DoBefore
+```
+
+
+#### `beforeEach`
+
+``` purescript
+beforeEach :: DoBefore
+```
+
+
+#### `DoBeforeTimeout`
+
+``` purescript
+type DoBeforeTimeout = forall eff a. Number -> Eff eff a -> Eff (before :: Before | eff) Unit
+```
+
+
+#### `before'`
+
+``` purescript
+before' :: DoBeforeTimeout
+```
+
+
+#### `beforeEach'`
+
+``` purescript
+beforeEach' :: DoBeforeTimeout
+```
+
+
+#### `DoBeforeAsync`
+
+``` purescript
+type DoBeforeAsync = forall eff a. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (before :: Before | eff) Unit
+```
+
+
+#### `beforeAsync`
+
+``` purescript
+beforeAsync :: DoBeforeAsync
+```
+
+
+#### `beforeEachAsync`
+
+``` purescript
+beforeEachAsync :: DoBeforeAsync
+```
+
+
+#### `DoBeforeAsyncTimeout`
+
+``` purescript
+type DoBeforeAsyncTimeout = forall eff a. Number -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (before :: Before | eff) Unit
+```
+
+
+#### `beforeAsync'`
+
+``` purescript
+beforeAsync' :: DoBeforeAsyncTimeout
+```
+
+
+#### `beforeEachAsync'`
+
+``` purescript
+beforeEachAsync' :: DoBeforeAsyncTimeout
+```
+
+
+#### `DoAfter`
+
+``` purescript
+type DoAfter = forall eff a. Eff eff a -> Eff (after :: After | eff) Unit
+```
+
+
+#### `after`
+
+``` purescript
+after :: DoAfter
+```
+
+
+#### `afterEach`
+
+``` purescript
+afterEach :: DoAfter
+```
+
+
+#### `DoAfterTimeout`
+
+``` purescript
+type DoAfterTimeout = forall eff a. Number -> Eff eff a -> Eff (after :: After | eff) Unit
+```
+
+
+#### `after'`
+
+``` purescript
+after' :: DoAfterTimeout
+```
+
+
+#### `afterEach'`
+
+``` purescript
+afterEach' :: DoAfterTimeout
+```
+
+
+#### `DoAfterAsync`
+
+``` purescript
+type DoAfterAsync = forall eff a. (DoneToken -> Eff (done :: Done | eff) a) -> Eff (after :: After | eff) Unit
+```
+
+
+#### `afterAsync`
+
+``` purescript
+afterAsync :: DoAfterAsync
+```
+
+
+#### `afterEachAsync`
+
+``` purescript
+afterEachAsync :: DoAfterAsync
+```
+
+
+#### `DoAfterAsyncTimeout`
+
+``` purescript
+type DoAfterAsyncTimeout = forall eff a. Number -> (DoneToken -> Eff (done :: Done | eff) a) -> Eff (after :: After | eff) Unit
+```
+
+
+#### `afterAsync'`
+
+``` purescript
+afterAsync' :: DoAfterAsyncTimeout
+```
+
+
+#### `afterEachAsync'`
+
+``` purescript
+afterEachAsync' :: DoAfterAsyncTimeout
+```
+
+
 #### `itIs`
 
 ``` purescript

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "mocha": "~1.21.4",
     "purescript-oo-ffi": "~0.0.4",
-    "purescript-context": "~0.0.3"
+    "purescript-context": "~0.0.3",
+    "purescript-maybe": "~0.2.2",
+    "purescript-strings": "~0.4.5"
   },
   "ignore": [
     "**/.*",

--- a/src/Test/Mocha.purs
+++ b/src/Test/Mocha.purs
@@ -1,16 +1,35 @@
 module Test.Mocha
-  ( Describe(..), DoDescribe(..), DoBefore(..), DoAfter(..)
-  , It(..), DoIt(..)
+  ( Describe(..)
+  , It(..), Before(..), After(..)
   , itIs, itIsNot, Done(..), DoneToken(..)
-  , it, itAsync, itSkip, itOnly
-  , describe, describeSkip, describeOnly
-  , before, beforeEach, beforeAsync, beforeEachAsync, Before(..)
-  , after, afterEach, afterAsync, afterEachAsync, After(..)
+
+  , it, itOnly, itSkip
+  , it', itOnly', itSkip'
+  , itAsync, itOnlyAsync, itSkipAsync
+  , itAsync', itOnlyAsync', itSkipAsync'
+
+  , xit, xitOnly, xitSkip
+  , xit', xitOnly', xitSkip'
+  , xitAsync, xitOnlyAsync, xitSkipAsync
+  , xitAsync', xitOnlyAsync', xitSkipAsync'
+
+  , describe, describeOnly, describeSkip
+  , xdescribe, xdescribeOnly, xdescribeSkip
+
+  , before, before', beforeAsync, beforeAsync'
+  , beforeEach, beforeEach', beforeEachAsync, beforeEachAsync'
+
+  , after, after', afterAsync, afterAsync'
+  , afterEach, afterEach', afterEachAsync, afterEachAsync'
   ) where
 
 import Control.Monad.Eff
 import Data.Foreign.OOFFI
 import Context
+import Data.Function
+import Data.String
+import Data.Maybe
+import Data.Maybe.Unsafe (fromJust)
 
 foreign import data Before :: !
 foreign import data Describe :: !
@@ -18,82 +37,275 @@ foreign import data It :: !
 foreign import data After :: !
 foreign import data Done :: !
 
-type DoIt = forall e a.
-  String ->
-  Eff e a ->
-  Eff (it :: It | e) Unit
-
-type DoDescribe = forall e a.
-  String ->
-  Eff (describe :: Describe | e) a ->
-  Eff (describe :: Describe | e) Unit
-
-type DoBefore = forall e a.
-  Eff e a ->
-  Eff (before :: Before | e) Unit
-
-type DoAfter = forall e a.
-  Eff e a ->
-  Eff (after :: After | e) Unit
-
 data DoneToken = DoneToken
 
-describe :: DoDescribe
-describe = method2EffC "describe"
+-- |
+-- Resolve a property recursively
+--
+_resolveC :: forall eff.
+  Maybe Context -> [String] -> Eff (|eff) (Maybe Context)
+_resolveC ctx [] = pure ctx
+_resolveC Nothing [] =
+  getContext >>= pure <<< Just
+_resolveC ctx (x:xs) = do
+  c <- case ctx of
+        Just c  -> pure c
+        Nothing -> getContext
+  p <- getter x c
+  _resolveC (Just p) xs
 
-foreign import describeOnly
-  """function describeOnly(description) {
-      return function(fn) {
-        return function() {
-          PS.Context.getContext().describe.only(description, fn);
-        }
+resolveC :: forall eff. String -> Eff (|eff) Context
+resolveC xs = do
+  ctx <- _resolveC Nothing $ split "." xs
+  return $ fromJust ctx
+
+-- |
+-- Apply a context as a function
+--
+foreign import apply0Impl
+  """function apply0Impl (ctx) {
+      return function() {
+        ctx();
       }
-  }""" :: DoDescribe
+  }""" :: forall eff. Fn1 Context (Eff eff Unit)
+apply0 = runFn1 apply0Impl
 
-foreign import describeSkip
-  """function describeSkip(description) {
-      return function(fn) {
-        return function() {
-          PS.Context.getContext().describe.skip(description, fn);
-        }
+foreign import apply1Impl
+  """function apply1Impl (ctx, a) {
+      return function() {
+        ctx(a);
       }
-  }""" :: DoDescribe
+  }""" :: forall a eff. Fn2 Context a (Eff eff Unit)
+apply1 = runFn2 apply1Impl
 
-it :: DoIt
-it = method2EffC "it"
-
-foreign import itOnly
-  """function itOnly(description) {
-      return function(fn) {
-        return function() {
-          PS.Context.getContext().it.only(description, fn);
-        }
+foreign import apply2Impl
+  """function apply2Impl (ctx, a, b) {
+      return function() {
+        ctx(a, b);
       }
-  }""" :: DoIt
+  }""" :: forall a b eff. Fn3 Context a b (Eff eff Unit)
+apply2 = runFn3 apply2Impl
 
-foreign import itSkip
-  """function itSkip(description) {
-      return function(fn) {
-        return function() {
-          PS.Context.getContext().it.skip(description, fn);
+-- |
+-- Generate a handler
+--
+foreign import syncImpl
+  """function syncImpl(fn, timeout) {
+      return function() {
+        if (timeout > 0) {
+            this.timeout(timeout);
         }
+        fn();
       }
-  }""" :: DoIt
+  }""" :: forall a eff. Fn2
+            (Eff eff a)
+            (Number)
+            (Eff eff Unit)
+sync = runFn2 syncImpl
 
-foreign import itAsync
-  """function itAsync(description) {
-      return function (fn) {
-        return function() {
-          return PS.Context.getContext().it(description, function(done) {
-            return fn(done)();
-          });
-        };
-      };
-  }""" :: forall a eff.
-          String ->
-          (DoneToken -> Eff (done :: Done | eff) a) ->
-          Eff (it :: It | eff) Unit
+foreign import asyncImpl
+  """function asyncImpl(fn, timeout) {
+      return function(done) {
+        if (timeout > 0) {
+           this.timeout(timeout);
+        }
+        fn(done)();
+      }
+  }""" :: forall a eff. Fn2
+            (DoneToken -> Eff (done :: Done | eff) a)
+            (Number)
+            (Eff eff Unit)
+async = runFn2 asyncImpl
 
+-- |
+-- Easily register a runners and hooks.
+--
+run  n t to d fn = resolveC n >>= \c -> apply2 c d $ t fn to
+hook n t to fn   = resolveC n >>= \c -> apply1 c $ t fn to
+
+-- |
+-- `It`
+--
+
+runItSync_ :: forall a eff.
+    String ->
+    Number ->
+    String ->
+    Eff eff a ->
+    Eff (it :: It | eff) Unit
+runItSync_ n = run n sync
+
+runItSync     = runItSync_ "it"
+runItOnlySync = runItSync_ "it.only"
+runItSkipSync = runItSync_ "it.skip"
+
+it      = runItSync     0
+itOnly  = runItOnlySync 0
+itSkip  = runItSkipSync 0
+it'     = flip runItSync
+itOnly' = flip runItOnlySync
+itSkip' = flip runItSkipSync
+
+runItAsync_ :: forall a eff.
+    String ->
+    Number ->
+    String ->
+    (DoneToken -> Eff (done :: Done | eff) a) ->
+    Eff (it :: It | eff) Unit
+runItAsync_ n = run n async
+
+runItAsync     = runItAsync_ "it"
+runItOnlyAsync = runItAsync_ "it.only"
+runItSkipAsync = runItAsync_ "it.skip"
+
+itAsync      = runItAsync     0
+itOnlyAsync  = runItOnlyAsync 0
+itSkipAsync  = runItSkipAsync 0
+itAsync'     = flip runItAsync
+itOnlyAsync' = flip runItOnlyAsync
+itSkipAsync' = flip runItSkipAsync
+
+-- |
+-- `Xit`
+--
+
+runXitSync_ :: forall a eff.
+    String ->
+    Number ->
+    String ->
+    Eff eff a ->
+    Eff (it :: It | eff) Unit
+runXitSync_ n = run n sync
+
+runXitSync     = runXitSync_ "xit"
+runXitOnlySync = runXitSync_ "xit.only"
+runXitSkipSync = runXitSync_ "xit.skip"
+
+xit      = runXitSync     0
+xitOnly  = runXitOnlySync 0
+xitSkip  = runXitSkipSync 0
+xit'     = flip runXitSync
+xitOnly' = flip runXitOnlySync
+xitSkip' = flip runXitSkipSync
+
+runXitAsync_ :: forall a eff.
+    String ->
+    Number ->
+    String ->
+    (DoneToken -> Eff (done :: Done | eff) a) ->
+    Eff (it :: It | eff) Unit
+runXitAsync_ n = run n async
+
+runXitAsync     = runXitAsync_ "xit"
+runXitOnlyAsync = runXitAsync_ "xit.only"
+runXitSkipAsync = runXitAsync_ "xit.skip"
+
+xitAsync      = runXitAsync     0
+xitOnlyAsync  = runXitOnlyAsync 0
+xitSkipAsync  = runXitSkipAsync 0
+xitAsync'     = flip runXitAsync
+xitOnlyAsync' = flip runXitOnlyAsync
+xitSkipAsync' = flip runXitSkipAsync
+
+-- |
+-- `Describe`
+--
+runDesc_ :: forall eff a.
+  String ->
+  String ->
+  Eff (describe :: Describe | eff) a ->
+  Eff (describe :: Describe | eff) Unit
+runDesc_ n  = run n sync 0
+
+describe     = runDesc_ "describe"
+describeOnly = runDesc_ "describe.only"
+describeSkip = runDesc_ "describe.skip"
+
+-- |
+-- `Xdescribe`
+--
+runXdesc_ :: forall eff a.
+  String ->
+  String ->
+  Eff (describe :: Describe | eff) a ->
+  Eff (describe :: Describe | eff) Unit
+runXdesc_ n  = run n sync 0
+
+xdescribe     = runXdesc_ "xdescribe"
+xdescribeOnly = runXdesc_ "xdescribe.only"
+xdescribeSkip = runXdesc_ "xdescribe.skip"
+
+-- |
+-- Before / BeforeEach Hook
+--
+
+runBeforeSync_ :: forall eff a.
+  String ->
+  Number ->
+  Eff eff a ->
+  Eff (before :: Before | eff) Unit
+runBeforeSync_ n = hook n sync
+
+runBeforeSync     = runBeforeSync_ "before"
+runBeforeEachSync = runBeforeSync_ "beforeEach"
+
+before      = runBeforeSync 0
+before'     = runBeforeSync
+beforeEach  = runBeforeEachSync 0
+beforeEach' = runBeforeEachSync
+
+runBeforeAsync_ :: forall eff a.
+  String ->
+  Number ->
+  (DoneToken -> Eff (done :: Done | eff) a) ->
+  Eff (before :: Before | eff) Unit
+runBeforeAsync_ n = hook n async
+
+runBeforeAsync     = runBeforeAsync_ "before"
+runBeforeEachAsync = runBeforeAsync_ "beforeEach"
+
+beforeAsync      = runBeforeAsync 0
+beforeAsync'     = runBeforeAsync
+beforeEachAsync  = runBeforeEachAsync 0
+beforeEachAsync' = runBeforeEachAsync
+
+-- |
+-- After / AfterEach Hook
+--
+
+runAfterSync_ :: forall eff a.
+  String ->
+  Number ->
+  Eff eff a ->
+  Eff (after :: After | eff) Unit
+runAfterSync_ n = hook n sync
+
+runAfterSync     = runAfterSync_ "after"
+runAfterEachSync = runAfterSync_ "afterEach"
+
+after      = runAfterSync 0
+after'     = runAfterSync
+afterEach  = runAfterEachSync 0
+afterEach' = runAfterEachSync
+
+runAfterAsync_ :: forall eff a.
+  String ->
+  Number ->
+  (DoneToken -> Eff (done :: Done | eff) a) ->
+  Eff (after :: After | eff) Unit
+runAfterAsync_ n = hook n async
+
+runAfterAsync     = runAfterAsync_ "after"
+runAfterEachAsync = runAfterAsync_ "afterEach"
+
+afterAsync      = runAfterAsync 0
+afterAsync'     = runAfterAsync
+afterEachAsync  = runAfterEachAsync 0
+afterEachAsync' = runAfterEachAsync
+
+-- |
+-- Async completion triggers
+--
 foreign import itIs
   """function itIs(done) {
       return function() {
@@ -110,63 +322,3 @@ foreign import itIsNot
   }""" :: forall eff a.
           DoneToken ->
           Eff (done :: Done | eff) Unit
-
--- | Before Hooks
-
-before :: DoBefore
-before = method1EffC "before"
-
-beforeEach :: DoBefore
-beforeEach = method1EffC "beforeEach"
-
-foreign import beforeAsync
-  """function beforeAsync(fn) {
-      return function() {
-        PS.Context.getContext().before(function(done) {
-          return fn(done)();
-        });
-      };
-  }""" :: forall a eff.
-          (DoneToken -> Eff (done :: Done | eff) a) ->
-          Eff (it :: It | eff) Unit
-
-foreign import beforeEachAsync
-  """function beforeEachAsync(fn) {
-      return function() {
-        PS.Context.getContext().beforeEach(function(done) {
-          return fn(done)();
-        });
-      };
-  }""" :: forall a eff.
-          (DoneToken -> Eff (done :: Done | eff) a) ->
-          Eff (it :: It | eff) Unit
-
--- | After Hooks
-
-after :: DoAfter
-after = method1EffC "after"
-
-afterEach :: DoAfter
-afterEach = method1EffC "afterEach"
-
-foreign import afterAsync
-  """function afterAsync(fn) {
-      return function() {
-        PS.Context.getContext().after(function(done) {
-          return fn(done)();
-        });
-      };
-  }""" :: forall a eff.
-          (DoneToken -> Eff (done :: Done | eff) a) ->
-          Eff (it :: It | eff) Unit
-
-foreign import afterEachAsync
-  """function afterEachAsync(fn) {
-      return function() {
-        PS.Context.getContext().afterEach(function(done) {
-          return fn(done)();
-        });
-      };
-  }""" :: forall a eff.
-          (DoneToken -> Eff (done :: Done | eff) a) ->
-          Eff (it :: It | eff) Unit

--- a/src/Test/Mocha.purs
+++ b/src/Test/Mocha.purs
@@ -3,6 +3,8 @@ module Test.Mocha
   , It(..), Before(..), After(..)
   , itIs, itIsNot, Done(..), DoneToken(..)
 
+  , xit, xdescribe, xdescribe'
+
   , DoItSync(..), DoItSyncTimeout(..)
   , DoItAsync(..), DoItAsyncTimeout(..)
   , it, itOnly, itSkip
@@ -10,14 +12,8 @@ module Test.Mocha
   , itAsync, itOnlyAsync, itSkipAsync
   , itAsync', itOnlyAsync', itSkipAsync'
 
-  , xit, xitOnly, xitSkip
-  , xit', xitOnly', xitSkip'
-  , xitAsync, xitOnlyAsync, xitSkipAsync
-  , xitAsync', xitOnlyAsync', xitSkipAsync'
-
   , DoDescribe(..)
   , describe, describeOnly, describeSkip
-  , xdescribe, xdescribeOnly, xdescribeSkip
 
   , DoBefore(..), DoBeforeTimeout(..)
   , DoBeforeAsync(..), DoBeforeAsyncTimeout(..)
@@ -198,41 +194,8 @@ itSkipAsync' = flip runItSkipAsync
 -- `Xit`
 --
 
-runXitSync     = runItSync_ "xit"
-runXitOnlySync = runItSync_ "xit.only"
-runXitSkipSync = runItSync_ "xit.skip"
-
-xit      :: DoItSync
-xit      = runXitSync     0
-xitOnly  :: DoItSync
-xitOnly  = runXitOnlySync 0
-xitSkip  :: DoItSync
-xitSkip  = runXitSkipSync 0
-
-xit'     :: DoItSyncTimeout
-xit'     = flip runXitSync
-xitOnly' :: DoItSyncTimeout
-xitOnly' = flip runXitOnlySync
-xitSkip' :: DoItSyncTimeout
-xitSkip' = flip runXitSkipSync
-
-runXitAsync     = runItAsync_ "xit"
-runXitOnlyAsync = runItAsync_ "xit.only"
-runXitSkipAsync = runItAsync_ "xit.skip"
-
-xitAsync      :: DoItAsync
-xitAsync      = runXitAsync     0
-xitOnlyAsync  :: DoItAsync
-xitOnlyAsync  = runXitOnlyAsync 0
-xitSkipAsync  :: DoItAsync
-xitSkipAsync  = runXitSkipAsync 0
-
-xitAsync'     :: DoItAsyncTimeout
-xitAsync'     = flip runXitAsync
-xitOnlyAsync' :: DoItAsyncTimeout
-xitOnlyAsync' = flip runXitOnlyAsync
-xitSkipAsync' :: DoItAsyncTimeout
-xitSkipAsync' = flip runXitSkipAsync
+xit :: forall eff. String -> Eff eff Unit
+xit = flip (runItSync 0) $ pure unit
 
 -- |
 -- `Describe`
@@ -254,12 +217,11 @@ describeSkip = runDesc_ "describe.skip"
 -- |
 -- `Xdescribe`
 --
-xdescribe     :: DoDescribe
-xdescribe     = runDesc_ "xdescribe"
-xdescribeOnly :: DoDescribe
-xdescribeOnly = runDesc_ "xdescribe.only"
-xdescribeSkip :: DoDescribe
-xdescribeSkip = runDesc_ "xdescribe.skip"
+xdescribe  :: DoDescribe
+xdescribe  = runDesc_ "xdescribe"
+
+xdescribe' :: forall eff. String -> Eff eff Unit
+xdescribe' = flip (runDesc_ "xdescribe") $ pure unit
 
 -- |
 -- Before / BeforeEach Hook


### PR DESCRIPTION
This patch critically refactors `Mocha.purs` and brings a range of new features:
- Add prime version for every hook and `it` to add a custom timeout
- Add `xit`, `xdescribe` to mark pending tests
- Add all variants of `it` and `xit` for both the sync and the async version
- Add utility methods to make changes easier (`apply0 ... 2` and `syncImpl` and `asyncImpl`). This should make it easier to add more of mochas different suit-styles later on.

To get a better idea, you can contrast the exports of before and after the patch.
This patch **should not** break any existing code, however it does remove `DoIt(..)` and `DoDescribe(..)` from the exports which from what I gather only had to be exported to make the compiler happy. The new version of the code doesn't need the internal aliases and hence does not have to export them.

Also, the code is tested only manually as we have no test suite set up as it stands.
